### PR TITLE
Replace log with logrus

### DIFF
--- a/test/helper/kubernetes/kubernetes_helper.go
+++ b/test/helper/kubernetes/kubernetes_helper.go
@@ -5,7 +5,7 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/sender.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/sender.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net/http"
 	"net/http/cookiejar"

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/go-openapi/swag/json.go
+++ b/vendor/github.com/go-openapi/swag/json.go
@@ -17,7 +17,7 @@ package swag
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/go-openapi/swag/loading.go
+++ b/vendor/github.com/go-openapi/swag/loading.go
@@ -17,7 +17,7 @@ package swag
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/gogo/protobuf/proto/clone.go
+++ b/vendor/github.com/gogo/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/gogo/protobuf/proto/equal.go
+++ b/vendor/github.com/gogo/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/gogo/protobuf/proto/lib.go
+++ b/vendor/github.com/gogo/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/gogo/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/gogo/protobuf/proto/properties.go
+++ b/vendor/github.com/gogo/protobuf/proto/properties.go
@@ -42,7 +42,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/gogo/protobuf/proto/text.go
+++ b/vendor/github.com/gogo/protobuf/proto/text.go
@@ -45,7 +45,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/googleapis/gnostic/compiler/reader.go
+++ b/vendor/github.com/googleapis/gnostic/compiler/reader.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"runtime"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 )

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-hclog/stdlog.go
+++ b/vendor/github.com/hashicorp/go-hclog/stdlog.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 )
 

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/hcl/v2/doc.go
+++ b/vendor/github.com/hashicorp/hcl/v2/doc.go
@@ -9,7 +9,7 @@
 //     package main
 //
 //     import (
-//     	"log"
+//     	log "github.com/sourcegraph-ce/logrus"
 //     	"github.com/hashicorp/hcl/v2/hclsimple"
 //     )
 //

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform-exec/tfinstall/look_path.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfinstall/look_path.go
@@ -2,7 +2,7 @@ package tfinstall
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os/exec"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/klauspost/compress/zstd/zstd.go
+++ b/vendor/github.com/klauspost/compress/zstd/zstd.go
@@ -5,7 +5,7 @@ package zstd
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"math/bits"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/modern-go/concurrent/log.go
+++ b/vendor/github.com/modern-go/concurrent/log.go
@@ -2,7 +2,7 @@ package concurrent
 
 import (
 	"os"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"io/ioutil"
 )
 

--- a/vendor/golang.org/x/lint/golint/import.go
+++ b/vendor/golang.org/x/lint/golint/import.go
@@ -13,7 +13,7 @@ It has been updated to follow upstream changes in a few ways.
 import (
 	"fmt"
 	"go/build"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path"
 	"path/filepath"

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -10,7 +10,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"golang.org/x/oauth2"

--- a/vendor/golang.org/x/oauth2/transport.go
+++ b/vendor/golang.org/x/oauth2/transport.go
@@ -6,7 +6,7 @@ package oauth2
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"sync"
 )

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -6,7 +6,7 @@ package bidi
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // This implementation is a port based on the reference implementation found at:

--- a/vendor/golang.org/x/tools/cmd/goimports/goimports.go
+++ b/vendor/golang.org/x/tools/cmd/goimports/goimports.go
@@ -13,7 +13,7 @@ import (
 	"go/scanner"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/vendor/golang.org/x/tools/internal/gopathwalk/walk.go
+++ b/vendor/golang.org/x/tools/internal/gopathwalk/walk.go
@@ -11,7 +11,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/golang.org/x/tools/internal/imports/zstdlib.go
+++ b/vendor/golang.org/x/tools/internal/imports/zstdlib.go
@@ -3482,7 +3482,7 @@ var stdlib = map[string][]string{
 		"TempFile",
 		"WriteFile",
 	},
-	"log": []string{
+	log "github.com/sourcegraph-ce/logrus": []string{
 		"Fatal",
 		"Fatalf",
 		"Fatalln",

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 

--- a/vendor/google.golang.org/protobuf/compiler/protogen/protogen.go
+++ b/vendor/google.golang.org/protobuf/compiler/protogen/protogen.go
@@ -21,7 +21,7 @@ import (
 	"go/token"
 	"go/types"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path"
 	"path/filepath"

--- a/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
+++ b/vendor/google.golang.org/protobuf/reflect/protoregistry/registry.go
@@ -17,7 +17,7 @@ package protoregistry
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/k8s.io/klog/v2/klog.go
+++ b/vendor/k8s.io/klog/v2/klog.go
@@ -77,7 +77,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	stdLog "log"
+	stdLog log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"os"
 	"path/filepath"
@@ -1186,7 +1186,7 @@ func (l *loggingT) flushAll() {
 	}
 }
 
-// CopyStandardLogTo arranges for messages written to the Go "log" package's
+// CopyStandardLogTo arranges for messages written to the Go log "github.com/sourcegraph-ce/logrus" package's
 // default logs to also appear in the Google logs for the named and lower
 // severities.  Subsequent changes to the standard log's default output location
 // or format may break this behavior.


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-kubernetes-alpha', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
provider
openapi
templates
morph
scripts
.github
docs
vendor
test
.git
_about
payload
credentials-exec-auth
crd
wait
configmap
ingress
terraform-operator
service
namespace
role
vault
credentials-client-cert
cluster-with-resources
credentials-token
deployment
bigcrd
pod
psp
cluster
manifests
testdata
workflows
ISSUE_TEMPLATE
resources
go.opencensus.io
sigs.k8s.io
cloud.google.com
gopkg.in
google.golang.org
golang.org
k8s.io
github.com
plugin
stats
internal
resource
tag
trace
metric
ochttp
propagation
b3
view
internal
tagencoding
tracestate
internal
propagation
metricproducer
metricdata
yaml
structured-merge-diff
v4
value
go
storage
internal
iam
compute
optional
trace
version
metadata
inf.v0
yaml.v2
yaml.v3
protobuf
grpc
genproto
appengine
api
proto
cmd
compiler
reflect
internal
types
runtime
encoding
protoc-gen-go
internal_gengo
protogen
protodesc
protoreflect
protoregistry
descopts
genid
set
flags
filetype
detrand
impl
filedesc
descfmt
pragma
mapsort
encoding
strs
errors
fieldsort
version
messageset
tag
defval
text
known
descriptorpb
pluginpb
emptypb
anypb
timestamppb
durationpb
protoiface
protoimpl
prototext
protowire
keepalive
grpclog
health
stats
binarylog
codes
reflection
internal
backoff
connectivity
attributes
status
credentials
serviceconfig
resolver
tap
peer
balancer
encoding
metadata
grpc_health_v1
grpc_binarylog_v1
grpc_reflection_v1alpha
grpcrand
syscall
grpclog
transport
grpcutil
envconfig
binarylog
buffer
backoff
grpcsync
status
credentials
serviceconfig
resolver
channelz
balancerload
dns
passthrough
grpclb
base
roundrobin
state
proto
googleapis
rpc
iam
type
api
code
status
v1
expr
annotations
datastore
urlfetch
internal
internal
cloudkey
cloudpb
app_identity
datastore
urlfetch
base
log
remote_api
modules
storage
transport
googleapi
option
internal
iterator
v1
http
cert
internal
internal
propagation
dca
transport
internaloption
third_party
impersonate
gensupport
uritemplates
x
crypto
mod
net
lint
sys
xerrors
term
tools
oauth2
time
text
cast5
openpgp
pkcs12
s2k
armor
packet
elgamal
errors
internal
rc2
module
semver
http
idna
internal
context
http2
trace
httpguts
timeseries
ctxhttp
hpack
golint
unix
windows
plan9
internal
unsafeheader
internal
cmd
internal
go
goimports
event
imports
gopathwalk
fastwalk
gocommand
label
keys
core
ast
internal
gcexportdata
astutil
gcimporter
jwt
internal
google
jws
rate
unicode
secure
transform
bidi
norm
bidirule
klog
utils
apimachinery
apiextensions-apiserver
client-go
api
v2
integer
pointer
third_party
pkg
forked
golang
reflect
fields
watch
selection
labels
apis
types
runtime
conversion
util
api
version
meta
v1
unstructured
serializer
schema
protobuf
versioning
json
streaming
recognizer
queryparams
net
wait
intstr
json
naming
clock
yaml
sets
framer
runtime
validation
errors
field
meta
resource
equality
errors
pkg
apis
apiextensions
v1beta1
v1
install
third_party
transport
discovery
plugin
kubernetes
rest
dynamic
tools
pkg
util
restmapper
forked
golang
template
pkg
client
auth
openstack
azure
oidc
exec
gcp
scheme
watch
clientcmd
metrics
auth
api
v1
latest
apis
version
clientauthentication
v1beta1
v1alpha1
retry
jsonpath
cert
workqueue
keyutil
homedir
connrotation
flowcontrol
networking
storage
certificates
extensions
scheduling
discovery
autoscaling
node
coordination
admissionregistration
policy
authorization
apps
batch
apiserverinternal
authentication
events
core
flowcontrol
rbac
v1beta1
v1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v2beta2
v1
v2beta1
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1beta1
v1
v1beta1
v1
v1beta1
v1
v1beta2
v1beta1
v1
v1alpha1
v1beta1
v1
v1beta1
v1
v1
v1beta1
v1alpha1
v1beta1
v1
v1alpha1
form3tech-oss
gogo
ulikunitz
stretchr
getkin
modern-go
go-openapi
fatih
googleapis
mailru
zclconf
Azure
apparentlymart
golang
oklog
jmespath
go-logr
google
json-iterator
jstemmer
hashicorp
ghodss
spf13
mitchellh
imdario
davecgh
pmezard
aws
vmihailenco
klauspost
mattn
bgentry
agext
jwt-go
protobuf
proto
sortkeys
xz
lzma
internal
hash
xlog
testify
assert
kin-openapi
jsoninfo
openapi2
openapi3
reflect2
concurrent
swag
jsonpointer
color
gax-go
gnostic
v2
extensions
compiler
openapiv2
easyjson
jwriter
buffer
jlexer
go-cty
cty
set
json
function
convert
gocty
stdlib
go-autorest
logger
tracing
autorest
azure
date
adal
go-textseg
v13
textseg
protobuf
groupcache
proto
ptypes
protoc-gen-go
internal
any
empty
duration
timestamp
descriptor
gengogrpc
lru
run
go-jmespath
logr
gofuzz
go-cmp
cmp
internal
diff
flags
value
function
go
go-junit-report
parser
formatter
go-plugin
go-getter
yamux
terraform-plugin-go
go-checkpoint
terraform-exec
go-uuid
terraform-plugin-sdk
go-version
go-cleanhttp
terraform-plugin-test
terraform-json
hcl
go-safetemp
logutils
go-hclog
internal
plugin
helper
url
tfprotov5
tftypes
server
internal
toproto
fromproto
tfplugin5
internal
tfexec
tfinstall
version
v2
helper
logging
v2
v2
ext
hclsyntax
customdecode
yaml
pflag
go-homedir
go-testing-interface
go-wordwrap
hashstructure
mergo
go-spew
spew
go-difflib
difflib
aws-sdk-go
service
internal
private
aws
sts
sso
s3
stsiface
ssoiface
sdkmath
sdkio
sync
ini
s3shared
sdkrand
shareddefaults
strings
context
sdkuri
singleflight
s3err
arn
protocol
checksum
jsonrpc
json
eventstream
rest
restxml
query
restjson
xml
jsonutil
eventstreamapi
queryutil
xmlutil
ec2metadata
signer
csm
defaults
session
endpoints
request
awserr
corehandlers
awsutil
credentials
arn
client
v4
endpointcreds
ssocreds
ec2rolecreds
processcreds
stscreds
metadata
msgpack
codes
compress
huff0
fse
snappy
zstd
internal
xxhash
go-colorable
go-isatty
go-netrc
netrc
levenshtein
acceptance
helper
testdata
HPA
Job
Deployment
Secret
NonStructuredCustomResourceDefinition
NonStructuredCustomResource
DaemonSet
CronJob
CustomResource
ConfigMap
WaitFor
Namespace
StatefulSet
CustomResourceOAPI3
CustomResourceDefinition
state
kubernetes
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
4e
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
83
4f
d3
54
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)